### PR TITLE
feat: Add release workflow for signed AAB

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,43 @@
+name: Android Release Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: gradle
+
+      - name: Decode Keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > my-release-key.jks
+
+      - name: Grant execute permission for Gradlew
+        run: chmod +x FreeHands_Android_production_with_wrapper/gradlew
+
+      - name: Build Release AAB
+        run: |
+          export KEYSTORE_FILE=$(pwd)/my-release-key.jks
+          ./FreeHands_Android_production_with_wrapper/gradlew -p ./FreeHands_Android_production_with_wrapper bundleRelease
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-aab
+          path: FreeHands_Android_production_with_wrapper/FreeHands_Android_production_fixed/build/outputs/bundle/release/*.aab

--- a/FreeHands_Android_production_with_wrapper/FreeHands_Android_production_fixed/build.gradle
+++ b/FreeHands_Android_production_with_wrapper/FreeHands_Android_production_fixed/build.gradle
@@ -20,11 +20,21 @@ android {
         vectorDrawables.useSupportLibrary = true
     }
 
+    signingConfigs {
+        release {
+            storeFile file(System.getenv("KEYSTORE_FILE") ?: "my-release-key.jks")
+            storePassword System.getenv("KEYSTORE_PASSWORD")
+            keyAlias System.getenv("KEY_ALIAS")
+            keyPassword System.getenv("KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             debuggable false
+            signingConfig signingConfigs.release
         }
         debug {
             minifyEnabled false


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to build a signed Android App Bundle (AAB) for release. It also configures the Gradle build to handle signing.

Changes include:
- Added a `signingConfigs` block to `app/build.gradle` to enable release build signing using credentials from environment variables.
- Created a new workflow at `.github/workflows/android-release.yml`.
- The new workflow is triggered on pushes to tags (e.g., `v1.0.0`).
- It decodes a keystore from GitHub Secrets, builds a release AAB using `bundleRelease`, and uploads the resulting `.aab` file as a build artifact.

This sets up the project for automated release builds.