### PR TITLE
feat: Add robust release workflow with debug steps

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,16 +1,16 @@
-name: Android Release Build and Deploy
+name: Android Release Build & Deploy
 
 on:
+  workflow_dispatch:
   push:
-    tags:
-      - 'v*'
+    tags: [ 'v*' ]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout sources
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
@@ -18,61 +18,53 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: gradle
 
-      - name: Decode Keystore
+      # (Не обязательно, но полезно) Убедиться, что есть нужные SDK
+      - name: Install Android SDK components
         run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > my-release-key.jks
+          yes | sudo ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --licenses
+          sudo ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager \
+            "platform-tools" "platforms;android-34" "build-tools;34.0.0"
 
-      - name: Grant execute permission for Gradlew
+      - name: Decode keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > my-release-key.jks
+
+      - name: Decode Play service account JSON
+        run: echo "${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}" | base64 --decode > service-account.json
+
+      - name: Grant execute to Gradlew
         run: chmod +x FreeHands_Android_production_with_wrapper/gradlew
 
-      - name: Build Release AAB
+      # 🔎 Быстрая проверка наличия секретов/файлов (без утечки значений)
+      - name: Verify secrets/files presence
         run: |
-          export KEYSTORE_FILE=$(pwd)/my-release-key.jks
-          ./FreeHands_Android_production_with_wrapper/gradlew -p ./FreeHands_Android_production_with_wrapper bundleRelease
-        env:
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          [ -s my-release-key.jks ] && echo "keystore: OK" || (echo "keystore missing" && exit 1)
+          [ -s service-account.json ] && echo "service account json: OK" || (echo "service account json missing" && exit 1)
+          test -n "${{ secrets.KEYSTORE_PASSWORD }}" && echo "KEYSTORE_PASSWORD: OK" || (echo "KEYSTORE_PASSWORD missing" && exit 1)
+          test -n "${{ secrets.KEY_ALIAS }}" && echo "KEY_ALIAS: OK" || (echo "KEY_ALIAS missing" && exit 1)
+          test -n "${{ secrets.KEY_PASSWORD }}" && echo "KEY_PASSWORD: OK" || (echo "KEY_PASSWORD missing" && exit 1)
 
+      # 🧪 Посмотреть какие publish-таски реально есть у модуля
+      - name: List publish tasks
+        run: ./FreeHands_Android_production_with_wrapper/gradlew -p ./FreeHands_Android_production_with_wrapper :app:tasks --all | grep -i publish || true
+
+      # 🏗️ Сборка bundle с подробными логами
+      - name: Build AAB (bundleRelease)
+        env:
+          KEYSTORE_FILE: my-release-key.jks
+        run: ./FreeHands_Android_production_with_wrapper/gradlew -p ./FreeHands_Android_production_with_wrapper :app:bundleRelease --stacktrace --info --no-daemon
+
+      # ⬆️ Сохранить AAB как артефакт даже при сбое следующих шагов
       - name: Upload AAB artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: release-aab
           path: FreeHands_Android_production_with_wrapper/FreeHands_Android_production_fixed/build/outputs/bundle/release/*.aab
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: gradle
-
-      - name: Decode Keystore
-        run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > my-release-key.jks
-
-      - name: Decode Play Service Account JSON
-        run: echo "${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}" | base64 --decode > service-account.json
-
-      - name: Grant execute permission for Gradlew
-        run: chmod +x FreeHands_Android_production_with_wrapper/gradlew
-
-      - name: Publish to Google Play
-        run: |
-          export KEYSTORE_FILE=$(pwd)/my-release-key.jks
-          export PLAY_SERVICE_ACCOUNT_JSON=$(pwd)/service-account.json
-          ./FreeHands_Android_production_with_wrapper/gradlew -p ./FreeHands_Android_production_with_wrapper publishRelease
+      # 🚀 Публикация в Google Play (internal track)
+      - name: Publish to Play (internal)
         env:
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEYSTORE_FILE: my-release-key.jks
+          PLAY_SERVICE_ACCOUNT_JSON: service-account.json
+        run: ./FreeHands_Android_production_with_wrapper/gradlew -p ./FreeHands_Android_production_with_wrapper :app:publishRelease --stacktrace --info --no-daemon


### PR DESCRIPTION
This commit improves the release CI/CD pipeline by making it more robust and easier to debug.

Changes include:
- The workflow is now a single job that builds and then publishes.
- Added a step to explicitly install required Android SDK components.
- Added a verification step to ensure all required secrets and files are present before the build starts.
- Added a step to list available Gradle tasks to help with debugging.
- The AAB is now uploaded as an artifact even if the final publishing step fails.
- Gradle commands now run with `--stacktrace --info` for better logging.