### PR TITLE
fix: Fix local build failure from Play Publisher config

### DIFF
--- a/FreeHands_Android_production_with_wrapper/FreeHands_Android_production_fixed/build.gradle
+++ b/FreeHands_Android_production_with_wrapper/FreeHands_Android_production_fixed/build.gradle
@@ -59,10 +59,12 @@ android {
     }
 }
 
-play {
-    serviceAccountCredentials.set(file(System.getenv("PLAY_SERVICE_ACCOUNT_JSON")))
-    track.set("internal")
-    defaultToAppBundles.set(true)
+if (System.getenv("PLAY_SERVICE_ACCOUNT_JSON")) {
+    play {
+        serviceAccountCredentials.set(file(System.getenv("PLAY_SERVICE_ACCOUNT_JSON")))
+        track.set("internal")
+        defaultToAppBundles.set(true)
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The build was failing when run locally or in a non-release CI environment. This was because the Gradle Play Publisher plugin configuration was being evaluated even for debug builds, but it depends on a `PLAY_SERVICE_ACCOUNT_JSON` environment variable that is only set during a release deployment.

This commit wraps the `play` configuration block in a conditional check (`if (System.getenv("PLAY_SERVICE_ACCOUNT_JSON"))`) so that it is only evaluated when the necessary environment variable is present.

This resolves the local build failure and allows debug builds to run successfully without affecting the release deployment pipeline.